### PR TITLE
Sealed interface for oneOf + discriminator wrappers [DEV-24445]

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,42 +1,42 @@
-# Plan: Common interface generation para `oneOf` + `discriminator`
+# Plan: Common interface generation for `oneOf` + `discriminator`
 
-> **Contexto**: hoy `swagger_dart_code_generator` ignora el `discriminator` de
-> los wrappers polimórficos OpenAPI 3 y emite un anti-patrón de N campos
-> nullable paralelos sin interfaz común. Esto fuerza al consumer a escribir
-> cadenas manuales `wrapper.evm?.x ?? wrapper.solana?.x ?? ...` para cada
-> propiedad común, y nos cuesta hoy ~785 líneas de `chain_adapter` en
-> arnac-mobile que reimplementan a mano lo que el generator debería hacer solo.
+> **Context**: today `swagger_dart_code_generator` ignores the `discriminator`
+> of OpenAPI 3 polymorphic wrappers and emits an anti-pattern of N parallel
+> nullable fields with no common interface. This forces consumers to write
+> manual chains like `wrapper.evm?.x ?? wrapper.solana?.x ?? ...` for every
+> common property, and costs us today ~785 lines of `chain_adapter` in
+> arnac-mobile that hand-implement what the generator should produce on its own.
 >
-> Este plan introduce **generación automática de un `sealed class IXxx`** por
-> wrapper, con sus subtipos haciendo `implements IXxx`, y un getter
-> `IXxx? get active` en el wrapper que apunta al subtipo activo.
+> This plan introduces **automatic generation of a `sealed class IXxx`** per
+> wrapper, with its subtypes doing `implements IXxx`, and a `IXxx? get active`
+> getter on the wrapper that points to the currently populated subtype.
 
 ---
 
-## Decisiones cerradas
+## Closed decisions
 
-| #   | Decisión                                                           | Valor                                                                                                |
-| --- | ------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| 1   | Qué wrappers reciben tratamiento                                   | Todo schema con `discriminator.mapping`, ≥ 2 subtipos Y ≥ 1 prop común                               |
-| 2   | Transitive type unification                                        | Sí. Si una prop apunta a refs que TODOS son subtipos de otro wrapper W, el tipo del getter es `IW`.  |
-| 3   | Naming del interface                                               | `I<WrapperName>` (`IVault`, `IEnrichedChain`, ...)                                                   |
-| 4   | Naming del getter al subtipo activo                                | `active`                                                                                             |
-| 5   | Modificador de clase del interface                                 | `sealed class` (permite pattern matching exhaustivo + `_`/`default:` para forward-compat)            |
-| 6   | Lax intersection (props presentes en ≥ 80% de subtipos)            | Sí. Las que faltan: stub `@override T? get foo => null;` en el subtipo                               |
-| 7   | Exponer discriminator como string en el wrapper                    | **No**. Pattern matching ES el discriminador                                                         |
-| 8   | `_active` cacheado o computado                                     | **Cacheado** (field set en `fromJson`, no recomputado por acceso)                                    |
-| 9   | `_active` debe quedar fuera de `==`/`hashCode`/`copyWith`/`toJson` | Sí (la regex actual lo filtra por no ser `final`)                                                    |
-| 10  | Soporte para `separate_models: true`                               | Out of scope. Si alguien lo activa, degradar a `abstract interface class`. Follow-up.                |
-| 11  | Emitir `UnknownVault` placeholder para discriminator desconocido   | Out of scope. `vault.active` queda `null` si no matchea ningún case. Follow-up si aparece necesidad. |
+| #   | Decision                                                            | Value                                                                                            |
+| --- | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| 1   | Which wrappers receive the treatment                                | Every schema with `discriminator.mapping`, ≥ 2 subtypes AND ≥ 1 common prop                      |
+| 2   | Transitive type unification                                         | Yes. If a prop's refs are ALL subtypes of another wrapper W, the getter type is `IW`.            |
+| 3   | Interface naming                                                    | `I<WrapperName>` (`IVault`, `IEnrichedChain`, ...)                                               |
+| 4   | Naming of the getter for the active subtype                         | `active`                                                                                         |
+| 5   | Class modifier of the interface                                     | `sealed class` (enables exhaustive pattern matching + `_`/`default:` for forward-compat)         |
+| 6   | Lax intersection (props present in ≥ 80% of subtypes)               | Yes. Missing subtypes get a `@override T? get foo => null;` stub                                 |
+| 7   | Expose the discriminator as a string on the wrapper                 | **No**. Pattern matching IS the discriminator                                                    |
+| 8   | `_active` cached or computed                                        | **Cached** (field set in `fromJson`, not recomputed on access)                                   |
+| 9   | `_active` must stay out of `==`/`hashCode`/`copyWith`/`toJson`      | Yes (the existing regex filters it because it isn't `final`)                                     |
+| 10  | Support for `separate_models: true`                                 | Out of scope. If enabled, fall back to `abstract interface class`. Follow-up.                    |
+| 11  | Emit an `UnknownVault` placeholder for unknown discriminator values | Out of scope. `vault.active` stays `null` if no case matches. Follow-up if a real need shows up. |
 
 ---
 
-## Escala del cambio
+## Change scale
 
-El spec actual de Fordefi BFF (`arnac-mobile/swagger/bff-openapi.json`) tiene
-**~250 wrappers polimórficos** con `oneOf + discriminator`. Los más relevantes:
+The current Fordefi BFF spec (`arnac-mobile/swagger/bff-openapi.json`) has
+**~250 polymorphic wrappers** with `oneOf + discriminator`. The most relevant:
 
-| Wrapper                                                                      | Subtipos |
+| Wrapper                                                                      | Subtypes |
 | ---------------------------------------------------------------------------- | -------- |
 | `Transaction`, `CreateTransactionResponse`, `GetTransactionResponse`, etc.   | 24       |
 | `CreateTransactionRequest`, `PredictTransactionRequest`, `PredictedSpotSwap` | 23-24    |
@@ -44,191 +44,188 @@ El spec actual de Fordefi BFF (`arnac-mobile/swagger/bff-openapi.json`) tiene
 | `UserAction`                                                                 | 17       |
 | `Vault`, `CreateVaultResponse`, `GetVaultResponse`                           | 15       |
 | `EnrichedChain`, `EnrichedAddress`, `AssetIdentifier`, `AddressBookContact`  | 12-13    |
-| ... ~200 más con 2-7 subtipos                                                |          |
+| ... ~200 more with 2-7 subtypes                                              |          |
 
-Después del filtro automático (≥ 2 subtipos Y ≥ 1 prop común con tipos
-compatibles), estimamos ~150-200 wrappers reciben IXxx. El diff esperado en
-`bff_openapi.swagger.dart` (hoy 212K líneas) crece ~1500-3000 líneas, todas
-aditivas.
+After the automatic filter (≥ 2 subtypes AND ≥ 1 common prop with compatible
+types), we estimate ~150-200 wrappers receive an IXxx. The expected diff in
+`bff_openapi.swagger.dart` (today 212K lines) grows ~1500-3000 lines, all
+additive.
 
 ---
 
-## Fases del trabajo
+## Work phases
 
-### Fase 1 — Cambio al generator
+### Phase 1 — Generator change
 
-Archivos a tocar en `~/projects/swagger_generator/`:
+Files touched in `~/projects/swagger_generator/`:
 
-- `lib/src/code_generators/swagger_models_generator.dart` (~+250 líneas, ~30
-  modificadas)
+- `lib/src/code_generators/swagger_models_generator.dart` (~+250 lines, ~30
+  modified)
 
-Estructura de la implementación:
+Implementation outline:
 
-1. **Data classes** (top-level al final del archivo):
+1. **Data classes** (top-level at the end of the file):
    - `OneOfCommonProp { snakeName, camelName, dartType, isNullable }`
    - `OneOfInterfaceInfo { wrapperName, interfaceName, commonProps, allSubtypeNames }`
    - `OneOfSubtypeMembership { interface, missingProps }`
 
-2. **Estado privado en `SwaggerModelsGenerator`**:
+2. **Private state on `SwaggerModelsGenerator`**:
 
    ```dart
    Map<String, OneOfInterfaceInfo>? _oneOfWrappers;
    Map<String, List<OneOfSubtypeMembership>>? _oneOfSubtypes;
    ```
 
-3. **Método `_buildOneOfAnalysis(Map<String, SwaggerSchema> classes)`**:
-   - Itera schemas, encuentra los que tienen `discriminator.mapping` no vacío
-   - Para cada wrapper:
-     - Resuelve cada subtipo via `$ref` → schema
-     - Une `properties` (con `allOf` resuelto si aplica)
-     - Calcula intersección: por cada property name, signature normalizada
-       (`$ref` o `type+format` o `array<X>`)
-     - Threshold: incluir property si presente en ≥ `ceil(0.8 * count)` subtipos
-       Y todas las apariciones comparten signature
-     - Aplica transitive: si signature divergente pero todas las refs son
-       subtipos del mismo otro wrapper W (post first-pass), usa `IW` como
-       signature unificada
-   - Skipea wrappers con 1 subtipo o 0 common props
-   - Llena `_oneOfWrappers` y `_oneOfSubtypes`
+3. **Method `_buildOneOfAnalysis(Map<String, SwaggerSchema> classes)`**:
+   - Iterates schemas, finds those with a non-empty `discriminator.mapping`
+   - For each wrapper:
+     - Resolves every subtype via `$ref` → schema
+     - Unions `properties` (with `allOf` resolved if applicable)
+     - Computes intersection: for every property name, a normalized signature
+       (`$ref` or `type+format` or `array<X>`)
+     - Threshold: include a property if present in ≥ `ceil(0.8 * count)`
+       subtypes AND all occurrences share the same signature
+     - Applies transitive: if signatures diverge but every ref is a subtype of
+       the same other wrapper W (after the first pass), use `IW` as the unified
+       signature
+   - Skips wrappers with 1 subtype or 0 common props
+   - Populates `_oneOfWrappers` and `_oneOfSubtypes`
 
-4. **Llamada al pre-pass** al inicio de `generateBase`, después de
+4. **Pre-pass call** at the start of `generateBase`, after
    `classes.addAll(classesFromInnerClasses)`.
 
-5. **Método `_generateSealedInterface(OneOfInterfaceInfo info)`** que emite:
+5. **Method `_generateSealedInterface(OneOfInterfaceInfo info)`** that emits:
 
    ```dart
    sealed class IVault {
      String? get id;
      DateTime? get createdAt;
-     // ... un getter por commonProp, siempre nullable
+     // ... one getter per commonProp, always nullable
    }
    ```
 
-6. **Modificaciones a `generateModelClassString`**:
-   - Si es wrapper (en `_oneOfWrappers`):
-     - Prepend `_generateSealedInterface(info)` al output
-     - Modificar el cuerpo de la clase para agregar `IXxx? _active;` field
-       privado + `IXxx? get active => _active;` getter público
-   - Si es subtipo (en `_oneOfSubtypes`):
-     - Cambiar header `class X {` → `class X implements IY {`
-     - Append `@override T? get foo => null;` por cada `missingProp` antes del
-       `}` final
+6. **Changes to `generateModelClassString`**:
+   - If wrapper (in `_oneOfWrappers`):
+     - Prepend `_generateSealedInterface(info)` to the output
+     - Modify the class body to add an `IXxx? _active;` private field +
+       `IXxx? get active => _active;` public getter
+   - If subtype (in `_oneOfSubtypes`):
+     - Change the header `class X {` → `class X implements IY {`
+     - Append `@override T? get foo => null;` for each `missingProp` before the
+       final `}`
 
-7. **Modificación a `generatedFromJson`** (solo cuando `hasMapping`):
-   - Cada case del switch agrega `<varName>._active = <varName>.<subfield>;`
-     después del parse del subtipo
+7. **Change to `generatedFromJson`** (only when `hasMapping`):
+   - Each switch case appends `<varName>._active = <varName>.<subfield>;` after
+     parsing the subtype
 
-### Fase 2 — Tests unitarios del generator
+### Phase 2 — Generator unit tests
 
-En `test/` del fork, fixtures pequeños bajo control:
+In the fork's `test/`, small controlled fixtures:
 
-- **`oneof_strict_intersection_test.dart`**: schema con 3 subtipos que comparten
-  2 props con tipos idénticos. Verifica IXxx con 2 getters + `implements` en los
-  3 subtipos.
-- **`oneof_lax_intersection_test.dart`**: 3 subtipos, una prop solo en 2 de
-  los 3. Verifica que entra en IXxx como nullable y el subtipo faltante tiene
+- **`oneof_strict_intersection_test.dart`**: schema with 3 subtypes sharing 2
+  props with identical types. Verifies IXxx with 2 getters + `implements` on the
+  3 subtypes.
+- **`oneof_lax_intersection_test.dart`**: 3 subtypes, one prop only in 2 of
+  the 3. Verifies it enters IXxx as nullable and the missing subtype gets a
   `@override T? get foo => null;` stub.
-- **`oneof_transitive_test.dart`**: dos wrappers `Outer` e `Inner`; subtipos de
-  `Outer` tienen una prop apuntando a subtipos de `Inner`. Verifica que `IOuter`
-  tiene `IInner? get prop`.
-- **`oneof_skip_test.dart`**: wrapper con 1 subtipo (skip), wrapper con 0 props
-  comunes (skip).
-- **`oneof_type_enum_per_subtype_test.dart`**: caso real Vault — cada subtipo
-  tiene `type` con enum único. Verifica que `type` no entra en IXxx.
+- **`oneof_transitive_test.dart`**: two wrappers `Outer` and `Inner`; subtypes
+  of `Outer` have a prop pointing to subtypes of `Inner`. Verifies that `IOuter`
+  gets `IInner? get prop`.
+- **`oneof_skip_test.dart`**: wrapper with 1 subtype (skip), wrapper with 0
+  common props (skip).
+- **`oneof_type_enum_per_subtype_test.dart`**: real Vault case — each subtype
+  has `type` with a unique enum. Verifies `type` does NOT enter IXxx.
 
-Correr con `dart test` desde `~/projects/swagger_generator`.
+Run with `dart test` from `~/projects/swagger_generator`.
 
-### Fase 3 — Validación contra el schema real
+### Phase 3 — Validation against the real schema
 
-Sin commitear cambios a arnac-mobile:
+Without committing changes to arnac-mobile:
 
-1. Editar local `arnac-mobile/pubspec.yaml:135-138` temporalmente:
+1. Temporarily edit `arnac-mobile/pubspec.yaml:135-138`:
    ```yaml
    swagger_dart_code_generator:
      path: /Users/davidfaerman/projects/swagger_generator
    ```
-2. **Daisy/David corre** desde main worktree (no puedo correrlo yo):
+2. **David runs** from the main worktree (I can't run it myself):
    ```bash
    arnac-mobile/scripts/build.sh
    ```
-3. Comparar `lib/core/network/rest/swagger/bff_openapi.swagger.dart`
-   antes/después.
+3. Compare `lib/core/network/rest/swagger/bff_openapi.swagger.dart`
+   before/after.
 
-**Criterio de aceptación del diff**:
+**Diff acceptance criteria**:
 
-- Diff puramente aditivo. `git diff --stat` muestra solo adiciones de líneas,
-  sin deletions.
-- Cambios legítimos no-aditivos esperados (acotados): los headers de clases tipo
-  `class EvmVault {` → `class EvmVault implements IVault {` (una palabra
-  agregada inline).
-- Si hay líneas borradas en cualquier otro lado: **bug**, detengo y debuggeo.
+- Purely additive diff. `git diff --stat` shows only line additions, no
+  deletions.
+- Expected (bounded) non-additive changes: class headers like `class EvmVault {`
+  → `class EvmVault implements IVault {` (one inline word added).
+- If lines are deleted anywhere else: **bug**, I stop and debug.
 
-### Fase 4 — Compile check de arnac-mobile
+### Phase 4 — arnac-mobile compile check
 
-Con el output regenerado:
+With the regenerated output:
 
 ```bash
 arnac-mobile/scripts/analyze.sh
 ```
 
-Debe pasar limpio. Prueba: cero call-sites existentes rompen. Todo el código de
-hoy que hace `vault.evm?.X`, `chain.solana?.Y`, `addr.cosmos?.Z`, sigue
-compilando.
+Must pass cleanly. This proves: zero existing call-sites break. All code that
+today does `vault.evm?.X`, `chain.solana?.Y`, `addr.cosmos?.Z` still compiles.
 
 ```bash
 arnac-mobile/scripts/test-flutter.sh
 ```
 
-Los tests existentes que tocan Vault/Chain/Address/AssetIdentifier deben seguir
-verdes.
+Existing tests touching Vault/Chain/Address/AssetIdentifier must stay green.
 
-Si algo rompe acá, paro y muestro el error.
+If anything breaks here, I stop and surface the error.
 
-### Fase 5 — PR al fork + bump en arnac-mobile
+### Phase 5 — PR to the fork + bump in arnac-mobile
 
-Si Fase 4 pasa:
+If Phase 4 passes:
 
-1. Commit en branch `oneof-common-interface` del fork → push a
+1. Commit on the fork's `oneof-common-interface` branch → push to
    `arnac-io/swagger-dart-code-generator`
-2. PR contra `fordefi_master` con link a este plan
-3. Una vez mergeado: bump del `ref:` en `arnac-mobile/pubspec.yaml`
-4. `arnac-mobile/scripts/pub-get.sh` para fijar el lockfile
-5. PR en arnac-mobile que sube **sólo** el bump del ref + el output regenerado.
+2. PR against `fordefi_master` with a link to this plan
+3. Once merged: bump the `ref:` in `arnac-mobile/pubspec.yaml`
+4. `arnac-mobile/scripts/pub-get.sh` to pin the lockfile
+5. PR in arnac-mobile that ships **only** the ref bump + regenerated output.
 
-### Fase 6 (PR separado, opcional) — Cleanup de `chain_adapter`
+### Phase 6 (separate PR, optional) — `chain_adapter` cleanup
 
-Aprovechar la nueva API en arnac-mobile:
+Take advantage of the new API in arnac-mobile:
 
-- Reemplazar `chainVaultFrom(v)` por `v.active` directo
-- Reemplazar cadenas `??` por `wrapper.active?.X`
-- Borrar interfaces obsoletas (`ChainInfo`, `ChainAssetId`, `ChainVault`,
-  `ChainAddress`) si quedan vacías post-migración, o achicarlas a sólo los
-  miembros que el wrapper no provee
-- Eliminar `chain_adapter/factories.dart`
+- Replace `chainVaultFrom(v)` with `v.active` directly
+- Replace `??` chains with `wrapper.active?.X`
+- Delete obsolete interfaces (`ChainInfo`, `ChainAssetId`, `ChainVault`,
+  `ChainAddress`) if they end up empty post-migration, or shrink them to just
+  the members the wrapper doesn't provide
+- Delete `chain_adapter/factories.dart`
 
-Esperado: 785 líneas → ~200 líneas.
+Expected: 785 lines → ~200 lines.
 
 ---
 
-## Cómo se usa el código después
+## How the code is used afterwards
 
-### Acceso a campos comunes
+### Common field access
 
 ```dart
-// HOY:
+// TODAY:
 final name = vault.evm?.name
     ?? vault.solana?.name
     ?? vault.cosmos?.name
-    ?? /* ... 12 más */;
+    ?? /* ... 12 more */;
 
-// DESPUÉS:
+// AFTER:
 final name = vault.active?.name;
 ```
 
-### Pattern matching exhaustivo
+### Exhaustive pattern matching
 
 ```dart
-// HOY: 15-way if/else, sin compile-time guarantee
+// TODAY: 15-way if/else, no compile-time guarantee
 String describeVault(Vault v) {
   if (v.evm != null) return 'EVM: ${v.evm!.address}';
   if (v.solana != null) return 'Solana: ${v.solana!.address}';
@@ -236,120 +233,120 @@ String describeVault(Vault v) {
   return 'unknown';
 }
 
-// DESPUÉS: switch sobre sealed, compile-time exhaustive
+// AFTER: switch over a sealed type, compile-time exhaustive
 String describeVault(Vault v) => switch (v.active) {
   EvmVault(:final address)    => 'EVM: $address',
   SolanaVault(:final address) => 'Solana: $address',
-  // ... el compilador rompe el build si me falta un caso
+  // ... the compiler breaks the build if a case is missing
   null                        => 'unknown',
 };
 ```
 
-### Pattern matching con forward-compat
+### Pattern matching with forward-compat
 
 ```dart
-// Caso "no me importa cada chain, sólo agrupo":
+// "I don't care about each chain, just group them":
 final label = switch (vault.active) {
   EvmVault()    => 'EVM',
   SolanaVault() => 'Solana',
-  _             => 'other',     // ← nuevas chains caen acá, no rompe
+  _             => 'other',     // ← new chains fall here, no break
 };
 ```
 
-### Funciones genéricas que aceptan cualquier vault
+### Generic functions accepting any vault
 
 ```dart
 void displayVault(IVault vault) {
   print('${vault.name} (id: ${vault.id}, created: ${vault.createdAt})');
 }
 
-// Llamadas:
+// Calls:
 displayVault(vault.evm!);      // OK, EvmVault implements IVault
-displayVault(vault.active!);   // OK, active es IVault?
+displayVault(vault.active!);   // OK, active is IVault?
 ```
 
 ### Transitive: AssetIdentifier.chain ⇒ IEnrichedChain
 
 ```dart
-// HOY:
+// TODAY:
 final chainName = assetId.evm?.chain.name
     ?? assetId.solana?.chain.name
     ?? assetId.cosmos?.chain.name
-    ?? /* ... 10 más */;
+    ?? /* ... 10 more */;
 
-// DESPUÉS:
+// AFTER:
 final chainName = assetId.active?.chain?.name;
 //                                ^^^^^^^
-//                                IEnrichedChain? gracias a transitive
+//                                IEnrichedChain? via transitive unification
 ```
 
-### Identity preservada (no hay re-alocación)
+### Identity preserved (no re-allocation)
 
 ```dart
 final a = vault.active;
 final b = vault.active;
-identical(a, b);  // true — devuelve el mismo objeto cada vez
+identical(a, b);  // true — same object returned every time
 a == b;           // true
 ```
 
-Esto evita rebuilds espurios en Flutter cuando `vault` no cambia.
+This avoids spurious rebuilds in Flutter when `vault` doesn't change.
 
 ---
 
-## Validación
+## Validation
 
-### Nivel 1 — Tests unitarios del generator
+### Level 1 — Generator unit tests
 
-Output: ` dart test` en el fork.
+Output: `dart test` in the fork.
 
-Cubre: las 5 fixtures de Fase 2. Falla rápido si la lógica de intersección,
-transitive, o emisión de stubs rompe.
+Covers: the 5 fixtures from Phase 2. Fails fast if intersection, transitive, or
+stub-emission logic breaks.
 
-### Nivel 2 — Diff manual del output regenerado
+### Level 2 — Manual diff of the regenerated output
 
 ```bash
-# Después de regen:
+# After regen:
 git -C /Users/davidfaerman/projects/arnac diff arnac-mobile/lib/core/network/rest/swagger/bff_openapi.swagger.dart \
   | grep '^-[^-]'
-# Debería estar vacío excepto líneas de header tipo `class X {` modificadas a `class X implements IY {`
+# Should be empty except for class header lines `class X {` modified to `class X implements IY {`
 ```
 
-Si el grep muestra otra cosa borrada → bug.
+If grep shows anything else deleted → bug.
 
-### Nivel 3 — Static analyzer
+### Level 3 — Static analyzer
 
 ```bash
 arnac-mobile/scripts/analyze.sh
 ```
 
-Debe terminar con cero errores. Prueba: backward compatibility de call-sites.
+Must finish with zero errors. Proves: backward compatibility of call-sites.
 
-### Nivel 4 — Suite Flutter existente
+### Level 4 — Existing Flutter suite
 
 ```bash
 arnac-mobile/scripts/test-flutter.sh
 ```
 
-Cero regresiones en tests que tocan los 4 wrappers principales (Vault,
-EnrichedChain, EnrichedAddress, AssetIdentifier).
+Zero regressions in tests touching the 4 main wrappers (Vault, EnrichedChain,
+EnrichedAddress, AssetIdentifier).
 
-### Nivel 5 — Smoke test de la nueva API
+### Level 5 — Smoke test of the new API
 
-Test ad-hoc post-regen:
+Ad-hoc post-regen test:
 
 ```dart
 test('Vault.active works for EVM', () {
   final json = jsonDecode(evmVaultFixtureJson);
   final v = Vault.fromJson(json);
 
-  expect(v.evm, isNotNull);                // legacy path
-  expect(v.active, isNotNull);             // new path
-  expect(v.active, isA<EvmVault>());        // sealed/pattern compat
-  expect(v.active?.id, v.evm?.id);          // getter equivalence
-  expect(identical(v.active, v.evm), true); // identity preserved
+  expect(v.evm, isNotNull);                 // legacy path
+  expect(v.active, isNotNull);              // new path
+  expect(v.active, isA<EvmVault>());         // sealed/pattern compat
+  expect(v.active?.id, v.evm?.id);           // getter equivalence
+  expect(identical(v.active, v.evm), true);  // identity preserved
 });
 
-test('Vault.active null para discriminator desconocido', () {
+test('Vault.active null for unknown discriminator', () {
   final json = {'type': 'monad', /* fields */};
   final v = Vault.fromJson(json);
 
@@ -357,56 +354,55 @@ test('Vault.active null para discriminator desconocido', () {
 });
 ```
 
-### Nivel 6 — Equivalencia adapter ↔ active (durante Fase 6)
+### Level 6 — adapter ↔ active equivalence (during Phase 6)
 
-Antes de borrar `chainVaultFrom`, un test que para cada chain real:
+Before deleting `chainVaultFrom`, a test that, for every real chain:
 
 ```dart
 test('chainVaultFrom matches vault.active for $chain', () {
   final v = parseRealVaultJson(chain);
   expect(chainVaultFrom(v)?.name, v.active?.name);
   expect(chainVaultFrom(v)?.id, v.active?.id);
-  // ... etc para los ~14 campos comunes
+  // ... etc for the ~14 common fields
 });
 ```
 
-Si los 15 chains pasan → safe to delete `chainVaultFrom`.
+If all 15 chains pass → safe to delete `chainVaultFrom`.
 
 ---
 
-## Checkpoints de revisión
+## Review checkpoints
 
-Voy a parar y consultar en estos momentos:
+I'll stop and check in at these moments:
 
-1. **Post Fase 1**: muestro el diff del fork antes de pushearlo.
-2. **Post Fase 3 (diff de bff_openapi.swagger.dart)**: pasamos el diff juntos
-   antes de declarar éxito.
-3. **Si Fase 4 falla en analyze/test**: paro, muestro el error, debuggeamos
-   juntos.
-4. **Antes de Fase 5 (PR al fork)**: confirmás que el PR vaya.
-
----
-
-## Riesgos identificados
-
-| Riesgo                                                                       | Mitigación                                                                                                                                                                |
-| ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Bug en signature comparison entre subtipos → IXxx mal tipado                 | Tests unitarios cubriendo refs, primitivos con format, arrays                                                                                                             |
-| Diff de `bff_openapi.swagger.dart` enorme alarma al manager                  | Diff es 100% aditivo; verificable con `grep '^-[^-]'`. Si necesita, puedo hacer un modo selectivo (sólo Vault/Chain/Address/AssetIdentifier) controlable via `build.yaml` |
-| Colisión de nombres (subtipo con field `active`)                             | Pre-pass detecta y reporta. Si pasa, usar `$active` o variar el getter name vía option                                                                                    |
-| Performance: switch del fromJson recibe `vault._active = ...` extra por case | Trivial — un puntero por parse, O(1), no afecta hot paths                                                                                                                 |
-| `separate_models: true` activado en el futuro                                | Fuera de scope. El generator emitiría sealed con subtipos en otros archivos → compile error. Follow-up: detectar la flag y degradar a `abstract interface class`          |
-| BE agrega un chain nuevo y un switch sin `_` rompe el build de mobile        | **Comportamiento deseado** del sealed: te avisa que hay que manejarlo. Si querés graceful, escribís `_ => ...` en el switch desde el inicio                               |
+1. **After Phase 1**: I show the fork diff before pushing.
+2. **After Phase 3 (bff_openapi.swagger.dart diff)**: we walk the diff together
+   before declaring success.
+3. **If Phase 4 fails on analyze/test**: I stop, show the error, debug together.
+4. **Before Phase 5 (PR to fork)**: you confirm the PR should go out.
 
 ---
 
-## No incluido en este scope
+## Identified risks
 
-- Refactor de `chain_adapter` y call-sites en arnac-mobile (Fase 6, PR
-  separado).
-- Generación de `UnknownVault` placeholder (follow-up si aparece).
-- Soporte para `separate_models: true` (follow-up).
-- Configuración via `build.yaml` del threshold lax (80%) o del prefix `I`
+| Risk                                                                        | Mitigation                                                                                                                                                                 |
+| --------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Bug in signature comparison across subtypes → mistyped IXxx                 | Unit tests covering refs, primitives with format, arrays                                                                                                                   |
+| Huge `bff_openapi.swagger.dart` diff alarms the manager                     | Diff is 100% additive; verifiable with `grep '^-[^-]'`. If needed, I can do a selective mode (only Vault/Chain/Address/AssetIdentifier) controllable via `build.yaml`      |
+| Name collision (subtype with a field named `active`)                        | Pre-pass detects and reports. If it happens, use `$active` or vary the getter name via an option                                                                           |
+| Performance: `fromJson` switch gets an extra `vault._active = ...` per case | Trivial — one pointer per parse, O(1), doesn't affect hot paths                                                                                                            |
+| `separate_models: true` enabled in the future                               | Out of scope. The generator would emit a sealed class with subtypes in other files → compile error. Follow-up: detect the flag and fall back to `abstract interface class` |
+| BE adds a new chain and a `_`-less switch breaks the mobile build           | **Desired behavior** of sealed types: it warns you to handle it. If you want graceful, write `_ => ...` in the switch from day one                                         |
+
+---
+
+## Not in scope
+
+- Refactor of `chain_adapter` and call-sites in arnac-mobile (Phase 6, separate
+  PR).
+- Generation of an `UnknownVault` placeholder (follow-up if needed).
+- Support for `separate_models: true` (follow-up).
+- Configuration via `build.yaml` of the lax threshold (80%) or the `I` prefix
   (follow-up).
-- Migración a OpenAPI Generator + Dio (proyecto separado, bloqueado por manager
-  hoy).
+- Migration to OpenAPI Generator + Dio (separate project, blocked by manager
+  today).

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,412 @@
+# Plan: Common interface generation para `oneOf` + `discriminator`
+
+> **Contexto**: hoy `swagger_dart_code_generator` ignora el `discriminator` de
+> los wrappers polimórficos OpenAPI 3 y emite un anti-patrón de N campos
+> nullable paralelos sin interfaz común. Esto fuerza al consumer a escribir
+> cadenas manuales `wrapper.evm?.x ?? wrapper.solana?.x ?? ...` para cada
+> propiedad común, y nos cuesta hoy ~785 líneas de `chain_adapter` en
+> arnac-mobile que reimplementan a mano lo que el generator debería hacer solo.
+>
+> Este plan introduce **generación automática de un `sealed class IXxx`** por
+> wrapper, con sus subtipos haciendo `implements IXxx`, y un getter
+> `IXxx? get active` en el wrapper que apunta al subtipo activo.
+
+---
+
+## Decisiones cerradas
+
+| #   | Decisión                                                           | Valor                                                                                                |
+| --- | ------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------- |
+| 1   | Qué wrappers reciben tratamiento                                   | Todo schema con `discriminator.mapping`, ≥ 2 subtipos Y ≥ 1 prop común                               |
+| 2   | Transitive type unification                                        | Sí. Si una prop apunta a refs que TODOS son subtipos de otro wrapper W, el tipo del getter es `IW`.  |
+| 3   | Naming del interface                                               | `I<WrapperName>` (`IVault`, `IEnrichedChain`, ...)                                                   |
+| 4   | Naming del getter al subtipo activo                                | `active`                                                                                             |
+| 5   | Modificador de clase del interface                                 | `sealed class` (permite pattern matching exhaustivo + `_`/`default:` para forward-compat)            |
+| 6   | Lax intersection (props presentes en ≥ 80% de subtipos)            | Sí. Las que faltan: stub `@override T? get foo => null;` en el subtipo                               |
+| 7   | Exponer discriminator como string en el wrapper                    | **No**. Pattern matching ES el discriminador                                                         |
+| 8   | `_active` cacheado o computado                                     | **Cacheado** (field set en `fromJson`, no recomputado por acceso)                                    |
+| 9   | `_active` debe quedar fuera de `==`/`hashCode`/`copyWith`/`toJson` | Sí (la regex actual lo filtra por no ser `final`)                                                    |
+| 10  | Soporte para `separate_models: true`                               | Out of scope. Si alguien lo activa, degradar a `abstract interface class`. Follow-up.                |
+| 11  | Emitir `UnknownVault` placeholder para discriminator desconocido   | Out of scope. `vault.active` queda `null` si no matchea ningún case. Follow-up si aparece necesidad. |
+
+---
+
+## Escala del cambio
+
+El spec actual de Fordefi BFF (`arnac-mobile/swagger/bff-openapi.json`) tiene
+**~250 wrappers polimórficos** con `oneOf + discriminator`. Los más relevantes:
+
+| Wrapper                                                                      | Subtipos |
+| ---------------------------------------------------------------------------- | -------- |
+| `Transaction`, `CreateTransactionResponse`, `GetTransactionResponse`, etc.   | 24       |
+| `CreateTransactionRequest`, `PredictTransactionRequest`, `PredictedSpotSwap` | 23-24    |
+| `WebhookTransactionStatusChangeEvent_event`                                  | 22       |
+| `UserAction`                                                                 | 17       |
+| `Vault`, `CreateVaultResponse`, `GetVaultResponse`                           | 15       |
+| `EnrichedChain`, `EnrichedAddress`, `AssetIdentifier`, `AddressBookContact`  | 12-13    |
+| ... ~200 más con 2-7 subtipos                                                |          |
+
+Después del filtro automático (≥ 2 subtipos Y ≥ 1 prop común con tipos
+compatibles), estimamos ~150-200 wrappers reciben IXxx. El diff esperado en
+`bff_openapi.swagger.dart` (hoy 212K líneas) crece ~1500-3000 líneas, todas
+aditivas.
+
+---
+
+## Fases del trabajo
+
+### Fase 1 — Cambio al generator
+
+Archivos a tocar en `~/projects/swagger_generator/`:
+
+- `lib/src/code_generators/swagger_models_generator.dart` (~+250 líneas, ~30
+  modificadas)
+
+Estructura de la implementación:
+
+1. **Data classes** (top-level al final del archivo):
+   - `OneOfCommonProp { snakeName, camelName, dartType, isNullable }`
+   - `OneOfInterfaceInfo { wrapperName, interfaceName, commonProps, allSubtypeNames }`
+   - `OneOfSubtypeMembership { interface, missingProps }`
+
+2. **Estado privado en `SwaggerModelsGenerator`**:
+
+   ```dart
+   Map<String, OneOfInterfaceInfo>? _oneOfWrappers;
+   Map<String, List<OneOfSubtypeMembership>>? _oneOfSubtypes;
+   ```
+
+3. **Método `_buildOneOfAnalysis(Map<String, SwaggerSchema> classes)`**:
+   - Itera schemas, encuentra los que tienen `discriminator.mapping` no vacío
+   - Para cada wrapper:
+     - Resuelve cada subtipo via `$ref` → schema
+     - Une `properties` (con `allOf` resuelto si aplica)
+     - Calcula intersección: por cada property name, signature normalizada
+       (`$ref` o `type+format` o `array<X>`)
+     - Threshold: incluir property si presente en ≥ `ceil(0.8 * count)` subtipos
+       Y todas las apariciones comparten signature
+     - Aplica transitive: si signature divergente pero todas las refs son
+       subtipos del mismo otro wrapper W (post first-pass), usa `IW` como
+       signature unificada
+   - Skipea wrappers con 1 subtipo o 0 common props
+   - Llena `_oneOfWrappers` y `_oneOfSubtypes`
+
+4. **Llamada al pre-pass** al inicio de `generateBase`, después de
+   `classes.addAll(classesFromInnerClasses)`.
+
+5. **Método `_generateSealedInterface(OneOfInterfaceInfo info)`** que emite:
+
+   ```dart
+   sealed class IVault {
+     String? get id;
+     DateTime? get createdAt;
+     // ... un getter por commonProp, siempre nullable
+   }
+   ```
+
+6. **Modificaciones a `generateModelClassString`**:
+   - Si es wrapper (en `_oneOfWrappers`):
+     - Prepend `_generateSealedInterface(info)` al output
+     - Modificar el cuerpo de la clase para agregar `IXxx? _active;` field
+       privado + `IXxx? get active => _active;` getter público
+   - Si es subtipo (en `_oneOfSubtypes`):
+     - Cambiar header `class X {` → `class X implements IY {`
+     - Append `@override T? get foo => null;` por cada `missingProp` antes del
+       `}` final
+
+7. **Modificación a `generatedFromJson`** (solo cuando `hasMapping`):
+   - Cada case del switch agrega `<varName>._active = <varName>.<subfield>;`
+     después del parse del subtipo
+
+### Fase 2 — Tests unitarios del generator
+
+En `test/` del fork, fixtures pequeños bajo control:
+
+- **`oneof_strict_intersection_test.dart`**: schema con 3 subtipos que comparten
+  2 props con tipos idénticos. Verifica IXxx con 2 getters + `implements` en los
+  3 subtipos.
+- **`oneof_lax_intersection_test.dart`**: 3 subtipos, una prop solo en 2 de
+  los 3. Verifica que entra en IXxx como nullable y el subtipo faltante tiene
+  `@override T? get foo => null;` stub.
+- **`oneof_transitive_test.dart`**: dos wrappers `Outer` e `Inner`; subtipos de
+  `Outer` tienen una prop apuntando a subtipos de `Inner`. Verifica que `IOuter`
+  tiene `IInner? get prop`.
+- **`oneof_skip_test.dart`**: wrapper con 1 subtipo (skip), wrapper con 0 props
+  comunes (skip).
+- **`oneof_type_enum_per_subtype_test.dart`**: caso real Vault — cada subtipo
+  tiene `type` con enum único. Verifica que `type` no entra en IXxx.
+
+Correr con `dart test` desde `~/projects/swagger_generator`.
+
+### Fase 3 — Validación contra el schema real
+
+Sin commitear cambios a arnac-mobile:
+
+1. Editar local `arnac-mobile/pubspec.yaml:135-138` temporalmente:
+   ```yaml
+   swagger_dart_code_generator:
+     path: /Users/davidfaerman/projects/swagger_generator
+   ```
+2. **Daisy/David corre** desde main worktree (no puedo correrlo yo):
+   ```bash
+   arnac-mobile/scripts/build.sh
+   ```
+3. Comparar `lib/core/network/rest/swagger/bff_openapi.swagger.dart`
+   antes/después.
+
+**Criterio de aceptación del diff**:
+
+- Diff puramente aditivo. `git diff --stat` muestra solo adiciones de líneas,
+  sin deletions.
+- Cambios legítimos no-aditivos esperados (acotados): los headers de clases tipo
+  `class EvmVault {` → `class EvmVault implements IVault {` (una palabra
+  agregada inline).
+- Si hay líneas borradas en cualquier otro lado: **bug**, detengo y debuggeo.
+
+### Fase 4 — Compile check de arnac-mobile
+
+Con el output regenerado:
+
+```bash
+arnac-mobile/scripts/analyze.sh
+```
+
+Debe pasar limpio. Prueba: cero call-sites existentes rompen. Todo el código de
+hoy que hace `vault.evm?.X`, `chain.solana?.Y`, `addr.cosmos?.Z`, sigue
+compilando.
+
+```bash
+arnac-mobile/scripts/test-flutter.sh
+```
+
+Los tests existentes que tocan Vault/Chain/Address/AssetIdentifier deben seguir
+verdes.
+
+Si algo rompe acá, paro y muestro el error.
+
+### Fase 5 — PR al fork + bump en arnac-mobile
+
+Si Fase 4 pasa:
+
+1. Commit en branch `oneof-common-interface` del fork → push a
+   `arnac-io/swagger-dart-code-generator`
+2. PR contra `fordefi_master` con link a este plan
+3. Una vez mergeado: bump del `ref:` en `arnac-mobile/pubspec.yaml`
+4. `arnac-mobile/scripts/pub-get.sh` para fijar el lockfile
+5. PR en arnac-mobile que sube **sólo** el bump del ref + el output regenerado.
+
+### Fase 6 (PR separado, opcional) — Cleanup de `chain_adapter`
+
+Aprovechar la nueva API en arnac-mobile:
+
+- Reemplazar `chainVaultFrom(v)` por `v.active` directo
+- Reemplazar cadenas `??` por `wrapper.active?.X`
+- Borrar interfaces obsoletas (`ChainInfo`, `ChainAssetId`, `ChainVault`,
+  `ChainAddress`) si quedan vacías post-migración, o achicarlas a sólo los
+  miembros que el wrapper no provee
+- Eliminar `chain_adapter/factories.dart`
+
+Esperado: 785 líneas → ~200 líneas.
+
+---
+
+## Cómo se usa el código después
+
+### Acceso a campos comunes
+
+```dart
+// HOY:
+final name = vault.evm?.name
+    ?? vault.solana?.name
+    ?? vault.cosmos?.name
+    ?? /* ... 12 más */;
+
+// DESPUÉS:
+final name = vault.active?.name;
+```
+
+### Pattern matching exhaustivo
+
+```dart
+// HOY: 15-way if/else, sin compile-time guarantee
+String describeVault(Vault v) {
+  if (v.evm != null) return 'EVM: ${v.evm!.address}';
+  if (v.solana != null) return 'Solana: ${v.solana!.address}';
+  // ...
+  return 'unknown';
+}
+
+// DESPUÉS: switch sobre sealed, compile-time exhaustive
+String describeVault(Vault v) => switch (v.active) {
+  EvmVault(:final address)    => 'EVM: $address',
+  SolanaVault(:final address) => 'Solana: $address',
+  // ... el compilador rompe el build si me falta un caso
+  null                        => 'unknown',
+};
+```
+
+### Pattern matching con forward-compat
+
+```dart
+// Caso "no me importa cada chain, sólo agrupo":
+final label = switch (vault.active) {
+  EvmVault()    => 'EVM',
+  SolanaVault() => 'Solana',
+  _             => 'other',     // ← nuevas chains caen acá, no rompe
+};
+```
+
+### Funciones genéricas que aceptan cualquier vault
+
+```dart
+void displayVault(IVault vault) {
+  print('${vault.name} (id: ${vault.id}, created: ${vault.createdAt})');
+}
+
+// Llamadas:
+displayVault(vault.evm!);      // OK, EvmVault implements IVault
+displayVault(vault.active!);   // OK, active es IVault?
+```
+
+### Transitive: AssetIdentifier.chain ⇒ IEnrichedChain
+
+```dart
+// HOY:
+final chainName = assetId.evm?.chain.name
+    ?? assetId.solana?.chain.name
+    ?? assetId.cosmos?.chain.name
+    ?? /* ... 10 más */;
+
+// DESPUÉS:
+final chainName = assetId.active?.chain?.name;
+//                                ^^^^^^^
+//                                IEnrichedChain? gracias a transitive
+```
+
+### Identity preservada (no hay re-alocación)
+
+```dart
+final a = vault.active;
+final b = vault.active;
+identical(a, b);  // true — devuelve el mismo objeto cada vez
+a == b;           // true
+```
+
+Esto evita rebuilds espurios en Flutter cuando `vault` no cambia.
+
+---
+
+## Validación
+
+### Nivel 1 — Tests unitarios del generator
+
+Output: ` dart test` en el fork.
+
+Cubre: las 5 fixtures de Fase 2. Falla rápido si la lógica de intersección,
+transitive, o emisión de stubs rompe.
+
+### Nivel 2 — Diff manual del output regenerado
+
+```bash
+# Después de regen:
+git -C /Users/davidfaerman/projects/arnac diff arnac-mobile/lib/core/network/rest/swagger/bff_openapi.swagger.dart \
+  | grep '^-[^-]'
+# Debería estar vacío excepto líneas de header tipo `class X {` modificadas a `class X implements IY {`
+```
+
+Si el grep muestra otra cosa borrada → bug.
+
+### Nivel 3 — Static analyzer
+
+```bash
+arnac-mobile/scripts/analyze.sh
+```
+
+Debe terminar con cero errores. Prueba: backward compatibility de call-sites.
+
+### Nivel 4 — Suite Flutter existente
+
+```bash
+arnac-mobile/scripts/test-flutter.sh
+```
+
+Cero regresiones en tests que tocan los 4 wrappers principales (Vault,
+EnrichedChain, EnrichedAddress, AssetIdentifier).
+
+### Nivel 5 — Smoke test de la nueva API
+
+Test ad-hoc post-regen:
+
+```dart
+test('Vault.active works for EVM', () {
+  final json = jsonDecode(evmVaultFixtureJson);
+  final v = Vault.fromJson(json);
+
+  expect(v.evm, isNotNull);                // legacy path
+  expect(v.active, isNotNull);             // new path
+  expect(v.active, isA<EvmVault>());        // sealed/pattern compat
+  expect(v.active?.id, v.evm?.id);          // getter equivalence
+  expect(identical(v.active, v.evm), true); // identity preserved
+});
+
+test('Vault.active null para discriminator desconocido', () {
+  final json = {'type': 'monad', /* fields */};
+  final v = Vault.fromJson(json);
+
+  expect(v.active, isNull);     // graceful unknown
+});
+```
+
+### Nivel 6 — Equivalencia adapter ↔ active (durante Fase 6)
+
+Antes de borrar `chainVaultFrom`, un test que para cada chain real:
+
+```dart
+test('chainVaultFrom matches vault.active for $chain', () {
+  final v = parseRealVaultJson(chain);
+  expect(chainVaultFrom(v)?.name, v.active?.name);
+  expect(chainVaultFrom(v)?.id, v.active?.id);
+  // ... etc para los ~14 campos comunes
+});
+```
+
+Si los 15 chains pasan → safe to delete `chainVaultFrom`.
+
+---
+
+## Checkpoints de revisión
+
+Voy a parar y consultar en estos momentos:
+
+1. **Post Fase 1**: muestro el diff del fork antes de pushearlo.
+2. **Post Fase 3 (diff de bff_openapi.swagger.dart)**: pasamos el diff juntos
+   antes de declarar éxito.
+3. **Si Fase 4 falla en analyze/test**: paro, muestro el error, debuggeamos
+   juntos.
+4. **Antes de Fase 5 (PR al fork)**: confirmás que el PR vaya.
+
+---
+
+## Riesgos identificados
+
+| Riesgo                                                                       | Mitigación                                                                                                                                                                |
+| ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Bug en signature comparison entre subtipos → IXxx mal tipado                 | Tests unitarios cubriendo refs, primitivos con format, arrays                                                                                                             |
+| Diff de `bff_openapi.swagger.dart` enorme alarma al manager                  | Diff es 100% aditivo; verificable con `grep '^-[^-]'`. Si necesita, puedo hacer un modo selectivo (sólo Vault/Chain/Address/AssetIdentifier) controlable via `build.yaml` |
+| Colisión de nombres (subtipo con field `active`)                             | Pre-pass detecta y reporta. Si pasa, usar `$active` o variar el getter name vía option                                                                                    |
+| Performance: switch del fromJson recibe `vault._active = ...` extra por case | Trivial — un puntero por parse, O(1), no afecta hot paths                                                                                                                 |
+| `separate_models: true` activado en el futuro                                | Fuera de scope. El generator emitiría sealed con subtipos en otros archivos → compile error. Follow-up: detectar la flag y degradar a `abstract interface class`          |
+| BE agrega un chain nuevo y un switch sin `_` rompe el build de mobile        | **Comportamiento deseado** del sealed: te avisa que hay que manejarlo. Si querés graceful, escribís `_ => ...` en el switch desde el inicio                               |
+
+---
+
+## No incluido en este scope
+
+- Refactor de `chain_adapter` y call-sites en arnac-mobile (Fase 6, PR
+  separado).
+- Generación de `UnknownVault` placeholder (follow-up si aparece).
+- Soporte para `separate_models: true` (follow-up).
+- Configuración via `build.yaml` del threshold lax (80%) o del prefix `I`
+  (follow-up).
+- Migración a OpenAPI Generator + Dio (proyecto separado, bloqueado por manager
+  hoy).

--- a/lib/src/code_generators/swagger_models_generator.dart
+++ b/lib/src/code_generators/swagger_models_generator.dart
@@ -19,6 +19,18 @@ abstract class SwaggerModelsGenerator extends SwaggerGeneratorBase {
 
   SwaggerModelsGenerator(this._options);
 
+  /// Wrappers detected with `oneOf` + `discriminator.mapping` that should
+  /// emit a `sealed class I<wrapperName>` interface alongside themselves.
+  /// Populated by [_buildOneOfAnalysis] at the start of [generateBase].
+  /// Key: PascalCase wrapper class name.
+  Map<String, OneOfInterfaceInfo> _oneOfWrappers = {};
+
+  /// Subtype classes (concrete types referenced from some wrapper's
+  /// discriminator mapping) that need `implements I<wrapperName>` and
+  /// null-override stubs for any missing common property.
+  /// Key: PascalCase subtype class name.
+  Map<String, List<OneOfSubtypeMembership>> _oneOfSubtypes = {};
+
   String generate({
     required SwaggerRoot root,
     required String fileName,
@@ -293,6 +305,10 @@ abstract class SwaggerModelsGenerator extends SwaggerGeneratorBase {
     if (classes.isEmpty) {
       return allEnumsString;
     }
+
+    // Analyze `oneOf` + `discriminator` wrappers up front so
+    // generateModelClassString can decorate wrapper/subtype emissions.
+    _buildOneOfAnalysis(classes);
 
     var results = classes.keys.map((String className) {
       if (classes['enum'] != null) {
@@ -1548,15 +1564,44 @@ String toString() => jsonEncode(this);
 
     final createToJson = generateCreateToJson(schema, validatedClassName);
 
+    // ── oneOf-interface decorations ─────────────────────────────────────────
+    // For wrappers: prepend `sealed class I<wrapperName> { ... }`, inject a
+    // private `_active` field + public `active` getter inside the wrapper.
+    // For subtypes: append `implements IFoo[, IBar]` to the class header and
+    // emit `@override T? get foo => null;` stubs for missing common props.
+    final oneOfWrapperInfo = _oneOfWrappers[validatedClassName];
+    final oneOfSubtypeMemberships = _oneOfSubtypes[validatedClassName] ?? const [];
+
+    final oneOfInterfaceBlock = oneOfWrapperInfo == null
+        ? ''
+        : _generateSealedInterfaceBlock(oneOfWrapperInfo);
+
+    final oneOfWrapperExtras = oneOfWrapperInfo == null
+        ? ''
+        : _generateWrapperActiveMembers(oneOfWrapperInfo);
+
+    // A subtype can appear in the same wrapper's mapping under multiple
+    // discriminator values (e.g. `equal` and `not_equal` both point to the
+    // same payload class). That registers the same membership twice. Dedupe
+    // by interface name so we don't emit `implements IFoo, IFoo`.
+    final oneOfImplementsClause = oneOfSubtypeMemberships.isEmpty
+        ? ''
+        : ' implements ${oneOfSubtypeMemberships.map((m) => m.interface.interfaceName).toSet().join(', ')}';
+
+    final oneOfSubtypeStubs = oneOfSubtypeMemberships.isEmpty
+        ? ''
+        : _generateSubtypeMissingStubs(oneOfSubtypeMemberships);
+
     final generatedClass = '''
+$oneOfInterfaceBlock
 @JsonSerializable(explicitToJson: true $createToJson)
-class $validatedClassName{
+class $validatedClassName$oneOfImplementsClause{
 \t $validatedClassName($generatedConstructorProperties);\n
 \t$fromJson${hasMapping ? '' : ''}\n
 \t$toJson${hasMapping ? '' : ''}\n
 $generatedProperties
 \tstatic const fromJsonFactory = _\$${validatedClassName}FromJson;
-
+$oneOfWrapperExtras$oneOfSubtypeStubs
 $equalsOverride
 
 $toStringOverride
@@ -1569,6 +1614,46 @@ $copyWithMethod
     return generatedClass;
   }
 
+  /// Emits the `sealed class IXxx { ... }` block that lives next to a wrapper.
+  String _generateSealedInterfaceBlock(OneOfInterfaceInfo info) {
+    final getters = info.commonProps
+        .map((p) => '\t${p.dartType}? get ${p.camelName};')
+        .join('\n');
+    return '''
+/// Common contract for all subtypes of [${info.wrapperName}], generated from
+/// the OpenAPI `oneOf` + `discriminator` declaration. All subtypes
+/// (${info.subtypeNames.join(', ')}) `implements ${info.interfaceName}`,
+/// which enables exhaustive pattern matching on `${info.wrapperName}.active`.
+sealed class ${info.interfaceName} {
+$getters
+}
+''';
+  }
+
+  /// Emits the `_active` private field and public `active` getter that the
+  /// wrapper class exposes. Called inside the wrapper class body.
+  String _generateWrapperActiveMembers(OneOfInterfaceInfo info) {
+    return '\n\t${info.interfaceName}? _active;\n'
+        '\t${info.interfaceName}? get active => _active;\n';
+  }
+
+  /// Emits `@override T? get foo => null;` stubs for properties that some
+  /// subtype lacks but its IXxx interface requires.
+  String _generateSubtypeMissingStubs(List<OneOfSubtypeMembership> ms) {
+    // A subtype may participate in multiple interfaces; de-duplicate by
+    // property name so we don't emit conflicting stubs.
+    final seen = <String>{};
+    final lines = <String>[];
+    for (final m in ms) {
+      for (final p in m.missingProps) {
+        if (!seen.add(p.camelName)) continue;
+        lines.add('\t@override ${p.dartType}? get ${p.camelName} => null;');
+      }
+    }
+    if (lines.isEmpty) return '';
+    return '\n${lines.join('\n')}\n';
+  }
+
   String generatedFromJson(SwaggerSchema schema, String validatedClassName) {
     final hasMapping = schema.discriminator?.mapping.isNotEmpty ?? false;
     final reporterCode = '\t\tSwaggerReporterHelper.report(\'GenerateError in $validatedClassName \${ex.toString()}\');\n';
@@ -1576,6 +1661,23 @@ $copyWithMethod
       final discriminator = schema.discriminator!;
       final propertyName = discriminator.propertyName;
       final responseVar = validatedClassName.camelCase;
+
+      // If this wrapper produces an IXxx interface, each case must also
+      // populate the wrapper's `_active` field so callers get O(1) access
+      // without re-scanning the 15 nullable fields on every read.
+      final hasInterface = _oneOfWrappers.containsKey(validatedClassName);
+
+      String fieldNameFor(MapEntry<String, String> entry) =>
+          entry.key == 'dynamic' ? 'dynamicField' : entry.key.camelCase;
+
+      String caseBody(MapEntry<String, String> entry) {
+        final field = fieldNameFor(entry);
+        final assign =
+            '$responseVar.$field = _\$${entry.value.split('/').last.pascalCase}FromJson(json);';
+        final activeAssign =
+            hasInterface ? ' $responseVar._active = $responseVar.$field;' : '';
+        return 'case \'${entry.key}\': try { $assign$activeAssign } catch(ex) {$reporterCode} break;';
+      }
 
       return 'static $validatedClassName _\$${validatedClassName}FromJson(Map<String, dynamic> json) { '
           '\ttry { '
@@ -1586,12 +1688,12 @@ $copyWithMethod
           '\t\trethrow;'
           '}'
           '}\n\n'
-          '${discriminator.mapping.entries.map((entry) => '${entry.value.getRef()}? ${entry.key == 'dynamic' ? 'dynamicField' : entry.key.camelCase};').join('\n')}'
+          '${discriminator.mapping.entries.map((entry) => '${entry.value.getRef()}? ${fieldNameFor(entry)};').join('\n')}'
           '\n\n'
           'factory $validatedClassName.fromJson(Map<String, dynamic> json) {'
           '\t\tvar $responseVar = $validatedClassName();'
           '\t\tswitch (json[\'$propertyName\']) {'
-          '\t\t\t${discriminator.mapping.entries.map((entry) => 'case \'${entry.key}\': try { $responseVar.${entry.key == 'dynamic' ? 'dynamicField' : entry.key.camelCase} = _\$${entry.value.split('/').last.pascalCase}FromJson(json); } catch(ex) {$reporterCode} break;').join('\n')}'
+          '\t\t\t${discriminator.mapping.entries.map(caseBody).join('\n')}'
           '\t\t}'
           '\treturn $responseVar;'
           '}';
@@ -1841,6 +1943,272 @@ $allHashComponents;
     return currentProperties;
   }
 
+  // ===========================================================================
+  // oneOf + discriminator analysis
+  //
+  // Pre-pass that scans every schema with `discriminator.mapping`. For each
+  // such "wrapper" we compute the intersection of properties across all
+  // subtypes (strict where types agree exactly; lax for properties present in
+  // ≥ 80% of subtypes; transitive when a property points to refs that are
+  // themselves all subtypes of another wrapper, in which case the type is
+  // that wrapper's interface).
+  //
+  // The results populate [_oneOfWrappers] and [_oneOfSubtypes]; the emission
+  // code in [generateModelClassString] then consults these maps to:
+  //   - prepend a `sealed class I<wrapperName>` ahead of each wrapper class
+  //   - inject `IXxx? _active;` field + `active` getter into the wrapper
+  //   - add `implements IXxx` to subtype class headers
+  //   - emit `@override T? get foo => null;` stubs in subtypes lacking a
+  //     property that's part of the lax intersection
+  // ===========================================================================
+
+  void _buildOneOfAnalysis(Map<String, SwaggerSchema> classes) {
+    _oneOfWrappers = {};
+    _oneOfSubtypes = {};
+
+    // ---- Pass 1: collect candidate wrappers and their subtype schemas ----
+    final working = <String, _OneOfWorkingState>{};
+
+    classes.forEach((rawClassName, schema) {
+      final mapping = schema.discriminator?.mapping;
+      if (mapping == null || mapping.isEmpty) return;
+      if (mapping.length < 2) return;
+
+      final wrapperName = getValidatedClassName(rawClassName).pascalCase;
+
+      final subtypes = <_OneOfSubtypeRef>[];
+      for (final entry in mapping.entries) {
+        final refName = entry.value.split('/').last;
+        final subSchema = classes[getValidatedClassName(refName)];
+        if (subSchema == null) continue;
+        subtypes.add(_OneOfSubtypeRef(refName.pascalCase, subSchema));
+      }
+      if (subtypes.length < 2) return;
+
+      // Gather (snake_name → list of subtype-schema pairs that declare it).
+      // Skip property names listed in `options.ignoredKeys` — the generator
+      // filters those from subtype field emission, so promoting them to the
+      // interface would yield abstract getters with no concrete impl.
+      final ignored = <String>{
+        ...options.ignoredKeys,
+        ...options.ignoredKeys.map((k) => _safeCamelCase(k)),
+      };
+      final propMap = <String, List<_OneOfPropOccurrence>>{};
+      for (final st in subtypes) {
+        final props = _allPropsOf(st.schema, classes);
+        for (final pe in props.entries) {
+          if (ignored.contains(pe.key)) continue;
+          propMap
+              .putIfAbsent(pe.key, () => [])
+              .add(_OneOfPropOccurrence(st.name, pe.value));
+        }
+      }
+
+      final total = subtypes.length;
+      // threshold = ceil(0.8 * total)
+      final threshold = (total * 4 + 4) ~/ 5;
+
+      working[wrapperName] = _OneOfWorkingState(
+        wrapperName: wrapperName,
+        subtypes: subtypes,
+        propMap: propMap,
+        threshold: threshold,
+      );
+    });
+
+    // Reverse map: subtype name -> wrapper that owns it (for transitive pass).
+    final subtypeOwner = <String, String>{};
+    for (final w in working.values) {
+      for (final st in w.subtypes) {
+        subtypeOwner[st.name] = w.wrapperName;
+      }
+    }
+
+    // ---- Pass 2a: strict + lax intersection (signatures must agree) ----
+    for (final w in working.values) {
+      for (final entry in w.propMap.entries) {
+        final propName = entry.key;
+        final occurrences = entry.value;
+        if (occurrences.length < w.threshold) continue;
+
+        // Inline enums (e.g. `{type: string, enum: ['evm']}`) get materialized
+        // by the generator as a per-class enum (`EvmVaultTypeGenerated`) that
+        // diverges across subtypes even when the raw schema's type/format
+        // matches. Reject any prop where *any* occurrence carries an inline
+        // enum so we don't promise `String?` to consumers and then get
+        // `enums.XxxTypeGenerated` from the subtype's actual field.
+        if (occurrences.any((o) => _hasInlineEnum(o.schema))) continue;
+
+        final firstSig = _schemaSignature(occurrences.first.schema);
+        final allAgree =
+            occurrences.every((o) => _schemaSignature(o.schema) == firstSig);
+        if (!allAgree) continue;
+
+        final dartType = _schemaToDartType(occurrences.first.schema, classes);
+        if (dartType == kDynamic) continue;
+
+        w.commonProps.add(OneOfCommonProp(
+          snakeName: propName,
+          camelName: _safeCamelCase(propName),
+          dartType: dartType,
+        ));
+        w.acceptedPropNames.add(propName);
+      }
+    }
+
+    // ---- Pass 2b: transitive — a prop where all occurrences are refs to
+    // ---- subtypes of THE SAME other wrapper W can be exposed as IW? ----
+    for (final w in working.values) {
+      for (final entry in w.propMap.entries) {
+        final propName = entry.key;
+        if (w.acceptedPropNames.contains(propName)) continue;
+
+        final occurrences = entry.value;
+        if (occurrences.length < w.threshold) continue;
+        if (!occurrences.every((o) => o.schema.hasRef)) continue;
+
+        final ownerSet = <String>{};
+        for (final o in occurrences) {
+          final refName = o.schema.ref.split('/').last.pascalCase;
+          final owner = subtypeOwner[refName];
+          if (owner == null) {
+            ownerSet.clear();
+            break;
+          }
+          ownerSet.add(owner);
+        }
+        if (ownerSet.length != 1) continue;
+        final commonOwner = ownerSet.first;
+        // The owner wrapper must itself end up with a non-empty interface,
+        // otherwise IW won't be emitted. We can't fully verify that yet,
+        // but require commonProps > 0 at this point as a proxy.
+        final ownerState = working[commonOwner];
+        if (ownerState == null || ownerState.commonProps.isEmpty) continue;
+
+        w.commonProps.add(OneOfCommonProp(
+          snakeName: propName,
+          camelName: _safeCamelCase(propName),
+          dartType: 'I$commonOwner',
+        ));
+        w.acceptedPropNames.add(propName);
+      }
+    }
+
+    // ---- Pass 3: finalize. Skip wrappers with no common props. ----
+    for (final w in working.values) {
+      if (w.commonProps.isEmpty) continue;
+
+      final info = OneOfInterfaceInfo(
+        wrapperName: w.wrapperName,
+        interfaceName: 'I${w.wrapperName}',
+        commonProps: List.unmodifiable(w.commonProps),
+        subtypeNames: w.subtypes.map((s) => s.name).toList(growable: false),
+      );
+      _oneOfWrappers[w.wrapperName] = info;
+
+      for (final st in w.subtypes) {
+        final declared = _allPropsOf(st.schema, classes);
+        final missing = info.commonProps
+            .where((p) => !declared.containsKey(p.snakeName))
+            .toList(growable: false);
+        _oneOfSubtypes
+            .putIfAbsent(st.name, () => [])
+            .add(OneOfSubtypeMembership(
+              interface: info,
+              missingProps: missing,
+            ));
+      }
+    }
+  }
+
+  /// Collects all schema properties of [schema], merging properties from any
+  /// `allOf` references (resolved via [schemas]). Recursion is bounded.
+  Map<String, SwaggerSchema> _allPropsOf(
+    SwaggerSchema schema,
+    Map<String, SwaggerSchema> schemas, [
+    int depth = 5,
+  ]) {
+    if (depth == 0) return {};
+    final result = <String, SwaggerSchema>{};
+    for (final part in schema.allOf) {
+      if (part.hasRef) {
+        final refName = part.ref.split('/').last;
+        final refSchema = schemas[getValidatedClassName(refName)];
+        if (refSchema != null) {
+          result.addAll(_allPropsOf(refSchema, schemas, depth - 1));
+        }
+      } else {
+        result.addAll(part.properties);
+      }
+    }
+    result.addAll(schema.properties);
+    return result;
+  }
+
+  /// A normalized signature string used to decide whether two property
+  /// schemas are "the same type" across subtypes. Equal signatures imply the
+  /// generator will emit the same Dart type for them.
+  String _schemaSignature(SwaggerSchema s) {
+    if (s.hasRef) return 'ref:${s.ref.split('/').last}';
+    if (s.type == 'array') {
+      final items = s.items;
+      return 'array<${items == null ? '' : _schemaSignature(items)}>';
+    }
+    final type = s.type;
+    if (type.isEmpty) return 'unknown';
+    return '$type:${s.format}';
+  }
+
+  /// Maps a property's schema to the Dart type string used in the generated
+  /// interface getter. Always returned WITHOUT a trailing `?`; the caller
+  /// appends `?` when emitting the getter.
+  String _schemaToDartType(
+      SwaggerSchema s, Map<String, SwaggerSchema> schemas) {
+    if (s.hasRef) {
+      final refName = s.ref.split('/').last;
+      final pascal = refName.pascalCase;
+      final refSchema = schemas[getValidatedClassName(refName)];
+      if (refSchema?.isEnum == true) return 'enums.$pascal';
+      return pascal;
+    }
+    if (s.type == 'array') {
+      final items = s.items;
+      final inner =
+          items != null ? _schemaToDartType(items, schemas) : 'Object';
+      return 'List<$inner>';
+    }
+    switch (s.type) {
+      case 'string':
+        if (s.format == 'date-time') return 'DateTime';
+        return 'String';
+      case 'integer':
+        return 'int';
+      case 'number':
+        return 'double';
+      case 'boolean':
+        return 'bool';
+      case 'object':
+        return 'Map<String, dynamic>';
+      default:
+        return kDynamic;
+    }
+  }
+
+  /// camelCase that survives identifiers starting with an underscore or
+  /// reserved words. Falls back to the raw name if camelCase would empty it.
+  String _safeCamelCase(String name) {
+    final camel = name.camelCase;
+    return camel.isEmpty ? name : camel;
+  }
+
+  /// True when [s] declares an inline enum (i.e. has explicit `enum` values
+  /// but no `$ref` to a shared enum schema). Such props get materialized as
+  /// a per-class generated enum (e.g. `EvmVaultTypeGenerated`), so two
+  /// subtypes that look schema-identical still diverge in Dart and must be
+  /// excluded from the shared interface.
+  bool _hasInlineEnum(SwaggerSchema s) =>
+      !s.hasRef && s.enumValuesObj.isNotEmpty;
+
   Map<String, SwaggerSchema> getRequestBodiesFromRequests(SwaggerRoot root) {
     final paths = root.paths;
     if (paths.isEmpty) {
@@ -1881,4 +2249,98 @@ class JsonEnumValue {
 
   final String jsonKey;
   final String fromJson;
+}
+
+/// A property in the common interface for an `oneOf` + `discriminator` wrapper.
+/// Emitted as a nullable getter on the generated abstract interface.
+class OneOfCommonProp {
+  OneOfCommonProp({
+    required this.snakeName,
+    required this.camelName,
+    required this.dartType,
+  });
+
+  /// Original schema property name (e.g. "derivation_path").
+  final String snakeName;
+
+  /// Camel-cased property name used in Dart (e.g. "derivationPath").
+  final String camelName;
+
+  /// Dart type of the getter, WITHOUT trailing `?`. The interface always
+  /// declares getters as nullable, so callers see `T?`.
+  /// E.g. "String", "DateTime", "List<OwnedAsset>", "enums.MpcVaultState",
+  /// "IEnrichedChain" (transitive case).
+  final String dartType;
+}
+
+/// Describes one wrapper class with `oneOf` + `discriminator` and the
+/// `sealed class I<wrapperName>` interface to emit alongside it.
+class OneOfInterfaceInfo {
+  OneOfInterfaceInfo({
+    required this.wrapperName,
+    required this.interfaceName,
+    required this.commonProps,
+    required this.subtypeNames,
+  });
+
+  /// PascalCase name of the wrapper class (e.g. "Vault").
+  final String wrapperName;
+
+  /// Name of the generated interface class (e.g. "IVault").
+  final String interfaceName;
+
+  /// Common properties intersected across all subtypes of the discriminator.
+  final List<OneOfCommonProp> commonProps;
+
+  /// PascalCase names of all subtypes participating in the discriminator
+  /// mapping (e.g. ["EvmVault", "SolanaVault", ...]).
+  final List<String> subtypeNames;
+}
+
+/// Marks a subtype class that participates in a `oneOf` + `discriminator`
+/// wrapper. It must `implements <interface.interfaceName>` and provide
+/// `@override T? get name => null;` stubs for any common property it lacks.
+class OneOfSubtypeMembership {
+  OneOfSubtypeMembership({
+    required this.interface,
+    required this.missingProps,
+  });
+
+  final OneOfInterfaceInfo interface;
+
+  /// Properties present in `interface.commonProps` that this subtype's
+  /// schema does NOT declare. Each needs an explicit null-returning getter
+  /// override to satisfy the interface contract.
+  final List<OneOfCommonProp> missingProps;
+}
+
+/// Internal scratch state for [SwaggerModelsGenerator._buildOneOfAnalysis].
+/// Holds per-wrapper working sets while the multi-pass intersection runs.
+class _OneOfWorkingState {
+  _OneOfWorkingState({
+    required this.wrapperName,
+    required this.subtypes,
+    required this.propMap,
+    required this.threshold,
+  });
+
+  final String wrapperName;
+  final List<_OneOfSubtypeRef> subtypes;
+  final Map<String, List<_OneOfPropOccurrence>> propMap;
+  final int threshold;
+
+  final List<OneOfCommonProp> commonProps = [];
+  final Set<String> acceptedPropNames = {};
+}
+
+class _OneOfSubtypeRef {
+  _OneOfSubtypeRef(this.name, this.schema);
+  final String name;
+  final SwaggerSchema schema;
+}
+
+class _OneOfPropOccurrence {
+  _OneOfPropOccurrence(this.subtypeName, this.schema);
+  final String subtypeName;
+  final SwaggerSchema schema;
 }

--- a/test/generator_tests/oneof_interface_test.dart
+++ b/test/generator_tests/oneof_interface_test.dart
@@ -1,0 +1,453 @@
+// Tests for the `oneOf` + `discriminator` interface generation:
+//   • `sealed class IXxx` emission alongside the wrapper class
+//   • `implements IXxx` injection on each subtype
+//   • `_active` field + `active` getter on the wrapper
+//   • `@override T? get foo => null;` stubs in subtypes missing a lax-common prop
+//   • Transitive type unification (one wrapper's subtype implementing another wrapper's interface)
+//   • Edge cases: 1-subtype wrapper, 0-common-prop wrapper, enum-divergence rejection
+
+import 'package:swagger_dart_code_generator/src/code_generators/swagger_models_generator.dart';
+import 'package:swagger_dart_code_generator/src/code_generators/v3/swagger_models_generator_v3.dart';
+import 'package:swagger_dart_code_generator/src/models/generator_options.dart';
+import 'package:swagger_dart_code_generator/src/swagger_models/responses/swagger_schema.dart';
+import 'package:swagger_dart_code_generator/src/swagger_models/swagger_components.dart';
+import 'package:swagger_dart_code_generator/src/swagger_models/swagger_info.dart';
+import 'package:swagger_dart_code_generator/src/swagger_models/swagger_root.dart';
+import 'package:test/test.dart';
+
+// ─── fixture helpers ────────────────────────────────────────────────────────
+
+SwaggerRoot _root(Map<String, SwaggerSchema> schemas) => SwaggerRoot(
+      openapiVersion: '3.0.0',
+      basePath: '',
+      components: SwaggerComponents(
+        parameters: {},
+        schemas: schemas,
+        responses: {},
+        requestBodies: {},
+      ),
+      info: SwaggerInfo(title: 'test', version: '1'),
+      host: '',
+      paths: {},
+      tags: [],
+      schemes: [],
+      parameters: {},
+      definitions: {},
+      securityDefinitions: {},
+    );
+
+SwaggerSchema _wrapper({
+  required String propertyName,
+  required Map<String, String> mapping,
+}) =>
+    SwaggerSchema(
+      oneOf: mapping.values
+          .map((ref) => SwaggerSchema(ref: ref))
+          .toList(),
+      discriminator: Discriminator(
+        propertyName: propertyName,
+        mapping: mapping,
+      ),
+    );
+
+SwaggerSchema _string({String format = ''}) =>
+    SwaggerSchema(type: 'string', format: format);
+SwaggerSchema _bool() => SwaggerSchema(type: 'boolean');
+SwaggerSchema _ref(String name) =>
+    SwaggerSchema(ref: '#/components/schemas/$name');
+
+SwaggerSchema _objectWithProps(Map<String, SwaggerSchema> properties) =>
+    SwaggerSchema(type: 'object', properties: properties);
+
+SwaggerModelsGenerator _gen({bool overrideEquals = false}) =>
+    SwaggerModelsGeneratorV3(GeneratorOptions(
+      inputFolder: '',
+      outputFolder: '',
+      overrideEqualsAndHashcode: overrideEquals,
+    ));
+
+String _runGenerate(Map<String, SwaggerSchema> schemas) {
+  final generator = _gen();
+  return generator.generateBase(
+    root: _root(schemas),
+    fileName: 'test',
+    classes: Map.of(schemas),
+    allEnums: [],
+    generateEnumsMethods: false,
+  );
+}
+
+// ─── tests ───────────────────────────────────────────────────────────────────
+
+void main() {
+  group('strict intersection', () {
+    test('emits sealed IXxx, implements on subtypes, _active in wrapper', () {
+      final schemas = <String, SwaggerSchema>{
+        'EvmFoo': _objectWithProps({
+          'id': _string(),
+          'name': _string(),
+          'evm_only': _bool(),
+        }),
+        'SolanaFoo': _objectWithProps({
+          'id': _string(),
+          'name': _string(),
+          'solana_only': _bool(),
+        }),
+        'Foo': _wrapper(
+          propertyName: 'type',
+          mapping: {
+            'evm': '#/components/schemas/EvmFoo',
+            'solana': '#/components/schemas/SolanaFoo',
+          },
+        ),
+      };
+
+      final out = _runGenerate(schemas);
+
+      // Sealed interface block exists with the two strict-common getters.
+      expect(out, contains('sealed class IFoo {'));
+      expect(out, contains('String? get id;'));
+      expect(out, contains('String? get name;'));
+      // No EVM/Solana-only props leak into the interface.
+      expect(out, isNot(contains('get evmOnly;')));
+      expect(out, isNot(contains('get solanaOnly;')));
+
+      // Each subtype declares `implements IFoo`.
+      expect(out, contains('class EvmFoo implements IFoo{'));
+      expect(out, contains('class SolanaFoo implements IFoo{'));
+
+      // Wrapper exposes `_active` field + `active` getter.
+      expect(out, contains('IFoo? _active;'));
+      expect(out, contains('IFoo? get active => _active;'));
+
+      // fromJson switch sets _active for each case.
+      expect(out, contains("case 'evm':"));
+      expect(out, contains('foo._active = foo.evm;'));
+      expect(out, contains('foo._active = foo.solana;'));
+    });
+  });
+
+  group('lax intersection', () {
+    test('prop missing in 1 of 3 subtypes becomes nullable + null stub', () {
+      final schemas = <String, SwaggerSchema>{
+        'A': _objectWithProps({
+          'id': _string(),
+          'shared': _string(),
+        }),
+        'B': _objectWithProps({
+          'id': _string(),
+          'shared': _string(),
+        }),
+        'C': _objectWithProps({
+          'id': _string(),
+          'shared': _string(),
+        }),
+        'D': _objectWithProps({
+          'id': _string(),
+          'shared': _string(),
+        }),
+        'E': _objectWithProps({
+          'id': _string(),
+          // 'shared' missing — present in 4 of 5 = 80% threshold met
+        }),
+        'Container': _wrapper(
+          propertyName: 'type',
+          mapping: {
+            'a': '#/components/schemas/A',
+            'b': '#/components/schemas/B',
+            'c': '#/components/schemas/C',
+            'd': '#/components/schemas/D',
+            'e': '#/components/schemas/E',
+          },
+        ),
+      };
+
+      final out = _runGenerate(schemas);
+
+      // Interface includes the lax-common prop.
+      expect(out, contains('sealed class IContainer {'));
+      expect(out, contains('String? get shared;'));
+
+      // E (the one missing 'shared') has the override stub.
+      // A/B/C/D do NOT need stubs because their declared fields satisfy
+      // the interface contract covariantly.
+      final eClassRegion = _extractClass(out, 'E');
+      expect(eClassRegion, contains('@override String? get shared => null;'));
+
+      final aClassRegion = _extractClass(out, 'A');
+      expect(aClassRegion,
+          isNot(contains('@override String? get shared => null;')));
+    });
+  });
+
+  group('transitive type unification', () {
+    test('subtype-of-A inside B-subtype becomes IA in IB getter', () {
+      final schemas = <String, SwaggerSchema>{
+        // Wrapper A and its subtypes (so IA is generated).
+        'EvmA': _objectWithProps({
+          'name': _string(),
+        }),
+        'SolanaA': _objectWithProps({
+          'name': _string(),
+        }),
+        'A': _wrapper(
+          propertyName: 'type',
+          mapping: {
+            'evm': '#/components/schemas/EvmA',
+            'solana': '#/components/schemas/SolanaA',
+          },
+        ),
+
+        // Wrapper B: each subtype has `inner` that points to a SUBTYPE of A.
+        // Since signatures differ (EvmA vs SolanaA), strict rejects.
+        // Transitive: both refs are subtypes of A → IB.inner becomes IA?
+        'EvmB': _objectWithProps({
+          'inner': _ref('EvmA'),
+        }),
+        'SolanaB': _objectWithProps({
+          'inner': _ref('SolanaA'),
+        }),
+        'B': _wrapper(
+          propertyName: 'type',
+          mapping: {
+            'evm': '#/components/schemas/EvmB',
+            'solana': '#/components/schemas/SolanaB',
+          },
+        ),
+      };
+
+      final out = _runGenerate(schemas);
+
+      expect(out, contains('sealed class IA {'));
+      expect(out, contains('sealed class IB {'));
+      expect(out, contains('IA? get inner;'),
+          reason:
+              'B subtypes\' `inner` points to refs that are all subtypes of A; transitive should expose IA');
+    });
+  });
+
+  group('edge cases', () {
+    test('wrapper with 1 subtype: no IXxx emitted', () {
+      final schemas = <String, SwaggerSchema>{
+        'Only': _objectWithProps({
+          'x': _string(),
+        }),
+        'Wrap': _wrapper(
+          propertyName: 'type',
+          mapping: {'only': '#/components/schemas/Only'},
+        ),
+      };
+      final out = _runGenerate(schemas);
+      expect(out, isNot(contains('sealed class IWrap')));
+      expect(out, isNot(contains('IWrap? _active;')));
+      // Subtype is not decorated.
+      expect(out, contains('class Only{'));
+      expect(out, isNot(contains('class Only implements')));
+    });
+
+    test('wrapper with 0 common props: no IXxx emitted', () {
+      final schemas = <String, SwaggerSchema>{
+        'X1': _objectWithProps({
+          'only_a': _string(),
+        }),
+        'X2': _objectWithProps({
+          'only_b': _bool(),
+        }),
+        'X': _wrapper(
+          propertyName: 'type',
+          mapping: {
+            'one': '#/components/schemas/X1',
+            'two': '#/components/schemas/X2',
+          },
+        ),
+      };
+      final out = _runGenerate(schemas);
+      expect(out, isNot(contains('sealed class IX ')));
+      expect(out, isNot(contains('IX? _active;')));
+    });
+
+    test('property with divergent enum refs per subtype is rejected', () {
+      // Each subtype's `type` is a $ref to a chain-specific enum schema —
+      // strict comparison rejects because the $refs themselves differ.
+      final schemas = <String, SwaggerSchema>{
+        'EvmTypeGen': SwaggerSchema(type: 'string', enumValuesObj: ['evm']),
+        'SolanaTypeGen':
+            SwaggerSchema(type: 'string', enumValuesObj: ['solana']),
+        'EvmW': _objectWithProps({
+          'id': _string(),
+          'type': _ref('EvmTypeGen'),
+        }),
+        'SolanaW': _objectWithProps({
+          'id': _string(),
+          'type': _ref('SolanaTypeGen'),
+        }),
+        'W': _wrapper(
+          propertyName: 'type',
+          mapping: {
+            'evm': '#/components/schemas/EvmW',
+            'solana': '#/components/schemas/SolanaW',
+          },
+        ),
+      };
+      final out = _runGenerate(schemas);
+      expect(out, contains('sealed class IW {'));
+      expect(out, contains('String? get id;'));
+      // `type` must NOT enter the interface — types diverge.
+      expect(out, isNot(contains('get type;')));
+    });
+
+    test('property with INLINE enum per subtype is rejected (Fordefi pattern)',
+        () {
+      // The real BFF spec for Vault declares `type` inline in each subtype:
+      //   "type": { "type": "string", "enum": ["evm"] }    (in EvmVault)
+      //   "type": { "type": "string", "enum": ["solana"] } (in SolanaVault)
+      // Raw signatures match (both are `string:`), so a naive intersection
+      // would put `String? get type` into the interface. BUT the generator
+      // materializes inline enums as per-class types (`EvmVaultTypeGenerated`,
+      // `SolanaVaultTypeGenerated`) — meaning the subtype field types diverge
+      // even though the raw schemas look identical. Must be rejected.
+      final schemas = <String, SwaggerSchema>{
+        'EvmInlineW': _objectWithProps({
+          'id': _string(),
+          'type': SwaggerSchema(type: 'string', enumValuesObj: ['evm']),
+        }),
+        'SolanaInlineW': _objectWithProps({
+          'id': _string(),
+          'type': SwaggerSchema(type: 'string', enumValuesObj: ['solana']),
+        }),
+        'InlineW': _wrapper(
+          propertyName: 'type',
+          mapping: {
+            'evm': '#/components/schemas/EvmInlineW',
+            'solana': '#/components/schemas/SolanaInlineW',
+          },
+        ),
+      };
+      final out = _runGenerate(schemas);
+      expect(out, contains('sealed class IInlineW {'));
+      expect(out, contains('String? get id;'));
+      expect(out, isNot(contains('get type;')),
+          reason: 'Inline enums diverge in the generated Dart layer even when '
+              'the raw schema signature matches; must be excluded.');
+    });
+  });
+
+  group('regressions caught in first regen', () {
+    test('subtype referenced from multiple discriminator keys: implements emitted once',
+        () {
+      // Real-world pattern (BytesArgumentPayload): the same payload class
+      // is mapped from multiple discriminator values (`equal`, `not_equal`).
+      // The implements clause must NOT emit `implements IFoo, IFoo`.
+      final schemas = <String, SwaggerSchema>{
+        'PayloadA': _objectWithProps({
+          'id': _string(),
+          'shared': _string(),
+        }),
+        'PayloadB': _objectWithProps({
+          'id': _string(),
+          'shared': _string(),
+        }),
+        'DualKeyWrap': _wrapper(
+          propertyName: 'op',
+          mapping: {
+            'eq': '#/components/schemas/PayloadA',
+            'neq': '#/components/schemas/PayloadA', // same class, second key
+            'gt': '#/components/schemas/PayloadB',
+          },
+        ),
+      };
+      final out = _runGenerate(schemas);
+      // PayloadA appears under two keys: the implements clause must be
+      // deduped, otherwise `dart analyze` rejects with implements_repeated.
+      expect(out, contains('class PayloadA implements IDualKeyWrap{'));
+      expect(
+          out,
+          isNot(contains(
+              'class PayloadA implements IDualKeyWrap, IDualKeyWrap')));
+    });
+
+    test('properties listed in options.ignoredKeys are skipped from the interface',
+        () {
+      final schemas = <String, SwaggerSchema>{
+        'IgA': _objectWithProps({
+          'id': _string(),
+          'metadata_uri': _string(),
+        }),
+        'IgB': _objectWithProps({
+          'id': _string(),
+          'metadata_uri': _string(),
+        }),
+        'IgWrap': _wrapper(
+          propertyName: 'type',
+          mapping: {
+            'a': '#/components/schemas/IgA',
+            'b': '#/components/schemas/IgB',
+          },
+        ),
+      };
+      final generator =
+          SwaggerModelsGeneratorV3(GeneratorOptions(
+        inputFolder: '',
+        outputFolder: '',
+        ignoredKeys: ['metadata_uri', 'metadataUri'],
+      ));
+      final out = generator.generateBase(
+        root: _root(schemas),
+        fileName: 'test',
+        classes: Map.of(schemas),
+        allEnums: [],
+        generateEnumsMethods: false,
+      );
+
+      expect(out, contains('sealed class IIgWrap {'));
+      expect(out, contains('String? get id;'));
+      // The ignored field must NOT enter the interface.
+      expect(out, isNot(contains('get metadataUri;')));
+    });
+  });
+
+  group('wrapper extras placement', () {
+    test('_active field and active getter live inside the wrapper class', () {
+      final schemas = <String, SwaggerSchema>{
+        'Aa': _objectWithProps({'id': _string()}),
+        'Bb': _objectWithProps({'id': _string()}),
+        'W2': _wrapper(
+          propertyName: 'type',
+          mapping: {
+            'a': '#/components/schemas/Aa',
+            'b': '#/components/schemas/Bb',
+          },
+        ),
+      };
+      final out = _runGenerate(schemas);
+      final wrapperRegion = _extractClass(out, 'W2');
+      expect(wrapperRegion, contains('IW2? _active;'));
+      expect(wrapperRegion, contains('IW2? get active => _active;'));
+    });
+  });
+}
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+/// Extracts the textual region of a generated class so we can assert that
+/// certain code is INSIDE a particular class (not just somewhere in the file).
+/// Returns the substring from `class <name>` up to the matching closing
+/// brace of that class.
+String _extractClass(String output, String className) {
+  final marker = RegExp('class\\s+$className(\\s+implements[^{]*)?\\s*\\{');
+  final match = marker.firstMatch(output);
+  if (match == null) {
+    throw StateError(
+        'class $className not found in generated output:\n${output.substring(0, output.length.clamp(0, 500))}');
+  }
+  // Walk forward, counting braces, until we close the class.
+  var depth = 1;
+  var i = match.end;
+  while (i < output.length && depth > 0) {
+    final c = output[i];
+    if (c == '{') depth++;
+    if (c == '}') depth--;
+    i++;
+  }
+  return output.substring(match.start, i);
+}


### PR DESCRIPTION
## Summary

- Each `oneOf` + `discriminator` schema now also emits a `sealed class I<WrapperName>` covering the intersection of common properties across its subtypes (strict + lax 80%, with `@override T? get foo => null;` stubs in subtypes missing a lax prop). Every subtype in the discriminator mapping gains `implements I<WrapperName>`.
- Wrappers expose `_active` (private, set in each `fromJson` switch case) + a public `active` getter. Consumers can write `vault.active?.name` or pattern-match exhaustively (`switch (vault.active) { case EvmVault(): … }`) instead of chaining `vault.evm?.x ?? vault.solana?.x ?? …`.
- Transitive type unification: when a property's refs are all subtypes of another wrapper W, its interface getter is typed as `IW?` (e.g. `IAssetIdentifier.chain` → `IEnrichedChain?`).
- Inline enums and `options.ignoredKeys` properties are excluded — they get materialized as per-class types or filtered entirely, so promoting them would break the contract.

Purely additive output: no existing fields, types, or JSON semantics change.

Full design rationale, decision record, and validation strategy in `PLAN.md` (added in this PR).

## Test plan

- [x] 10 unit tests in `test/generator_tests/oneof_interface_test.dart` covering strict/lax intersection, transitive unification, inline-enum rejection, ignored-keys filter, duplicate-discriminator-key dedup, and edge cases (1-subtype, 0 common props, divergent enum refs).
- [x] No regressions in existing fork test suite (13 pre-existing failures unchanged).
- [x] Regenerated `bff_openapi.swagger.dart` against arnac-mobile's BFF spec — 302 interfaces emitted; `dart analyze` passes cleanly.
- [x] 633 `fromJson` cases programmatically verified to assign `_active` to the matching subfield.
- [x] arnac-mobile `test-flutter` suite passes cleanly with regenerated output.
- [x] Manual smoke test on mobile app (vault list, chain selector, address book, asset display).
- [ ] Reviewer approval.

Follow-up: cleanup PR on arnac-mobile to delete `chain_adapter/factories.dart` (~785 lines) and replace call sites with `wrapper.active?.x`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)